### PR TITLE
Update radius as default has changed.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# hipscat_cloudtests
+# hipscat cloudtests
 
 [![Template](https://img.shields.io/badge/Template-LINCC%20Frameworks%20Python%20Project%20Template-brightgreen)](https://lincc-ppt.readthedocs.io/en/latest/)
 
-[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/astronomy-commons/hipscat_cloudtests/smoke-test.yml)](https://github.com/astronomy-commons/hipscat_cloudtests/actions/workflows/smoke-test.yml)
-[![benchmarks](https://img.shields.io/github/actions/workflow/status/astronomy-commons/hipscat_cloudtests/asv-main.yml?label=benchmarks)](https://astronomy-commons.github.io/hipscat_cloudtests/)
+[![GitHub Workflow Status](https://img.shields.io/github/actions/workflow/status/astronomy-commons/hipscat-cloudtests/smoke-test.yml)](https://github.com/astronomy-commons/hipscat-cloudtests/actions/workflows/smoke-test.yml)
+[![benchmarks](https://img.shields.io/github/actions/workflow/status/astronomy-commons/hipscat-cloudtests/asv-main.yml?label=benchmarks)](https://astronomy-commons.github.io/hipscat-cloudtests/)
 
 Integration tests for cloud read and write through HiPScat and LSDB libraries.
 

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -2,7 +2,9 @@ import pytest
 
 
 def test_kdtree_crossmatch(small_sky_catalog_cloud, small_sky_xmatch_catalog_cloud, xmatch_correct_cloud):
-    xmatched = small_sky_catalog_cloud.crossmatch(small_sky_xmatch_catalog_cloud).compute()
+    xmatched = small_sky_catalog_cloud.crossmatch(
+        small_sky_xmatch_catalog_cloud, radius_arcsec=0.01 * 3600
+    ).compute()
     assert len(xmatched) == len(xmatch_correct_cloud)
     for _, correct_row in xmatch_correct_cloud.iterrows():
         assert correct_row["ss_id"] in xmatched["id_small_sky"].values


### PR DESCRIPTION
Units and distance on default cross match radius changed in https://github.com/astronomy-commons/lsdb/pull/134

This resulted in smoke failures, and this PR sets the radius to the old default value (0.01 degrees).

Also fixes smoke test badge link on readme.