### PR TITLE
Address smoke test failure

### DIFF
--- a/tests/hipscat/catalog/test_catalog_cloud.py
+++ b/tests/hipscat/catalog/test_catalog_cloud.py
@@ -45,5 +45,6 @@ def test_empty_directory(tmp_dir_cloud, example_cloud_storage_options):
             catalog_path=catalog_path, storage_options=example_cloud_storage_options
         )
 
-        catalog = Catalog.read_from_hipscat(catalog_path, storage_options=example_cloud_storage_options)
+        with pytest.warns(UserWarning, match="slow"):
+            catalog = Catalog.read_from_hipscat(catalog_path, storage_options=example_cloud_storage_options)
         assert catalog.catalog_name == "empty"

--- a/tests/hipscat_import/test_run_catalog_import.py
+++ b/tests/hipscat_import/test_run_catalog_import.py
@@ -27,7 +27,7 @@ def test_catalog_import_write_to_cloud(
             output_artifact_name="small_sky_object_catalog",
             input_path=small_sky_parts_dir_local,
             output_storage_options=example_cloud_storage_options,
-            input_format="csv",
+            file_reader="csv",
             output_path=temp_path,
             dask_tmp=tmp_path,
             highest_healpix_order=1,
@@ -67,7 +67,6 @@ def test_catalog_import_read_from_cloud(
         output_artifact_name="small_sky_object_catalog",
         input_path=small_sky_parts_dir_cloud,
         input_storage_options=example_cloud_storage_options,
-        input_format="csv",
         file_reader=CsvReader(
             storage_options=example_cloud_storage_options,
         ),

--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -2,9 +2,10 @@ import pytest
 
 
 def test_kdtree_crossmatch(small_sky_catalog_cloud, small_sky_xmatch_catalog_cloud, xmatch_correct_cloud):
-    xmatched = small_sky_catalog_cloud.crossmatch(
-        small_sky_xmatch_catalog_cloud, radius_arcsec=0.01 * 3600
-    ).compute()
+    with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
+        xmatched = small_sky_catalog_cloud.crossmatch(
+            small_sky_xmatch_catalog_cloud, radius_arcsec=0.01 * 3600
+        ).compute()
     assert len(xmatched) == len(xmatch_correct_cloud)
     for _, correct_row in xmatch_correct_cloud.iterrows():
         assert correct_row["ss_id"] in xmatched["id_small_sky"].values


### PR DESCRIPTION
Changes in https://github.com/astronomy-commons/hipscat-import/pull/234 caused the hipscat-import tests to fail.

This also addresses some warnings that have been introduced recently.