### PR TITLE
Address smoke test failure

### DIFF
--- a/tests/lsdb/catalog/test_crossmatch.py
+++ b/tests/lsdb/catalog/test_crossmatch.py
@@ -4,7 +4,7 @@ import pytest
 def test_kdtree_crossmatch(small_sky_catalog_cloud, small_sky_xmatch_catalog_cloud, xmatch_correct_cloud):
     with pytest.warns(RuntimeWarning, match="Results may be inaccurate"):
         xmatched = small_sky_catalog_cloud.crossmatch(
-            small_sky_xmatch_catalog_cloud, radius_arcsec=0.01 * 3600
+            small_sky_xmatch_catalog_cloud, radius_arcsec=0.01 * 3600, require_right_margin=False
         ).compute()
     assert len(xmatched) == len(xmatch_correct_cloud)
     for _, correct_row in xmatch_correct_cloud.iterrows():


### PR DESCRIPTION
This addresses the smoke tests failure due to changes on hipscat.