### PR TITLE
Pin python 3.11 version in CI

### DIFF
--- a/.github/workflows/smoke-test.yml
+++ b/.github/workflows/smoke-test.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11.8']
 
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/testing-and-coverage.yml
+++ b/.github/workflows/testing-and-coverage.yml
@@ -15,7 +15,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.9', '3.10', '3.11']
+        python-version: ['3.9', '3.10', '3.11.8']
 
     steps:
     - uses: actions/checkout@v4


### PR DESCRIPTION
## Change Description

Smoke tests are failing with silly errors that seem related to recent regressions in dask with python 3.11.8->3.11.9.

https://github.com/dask/dask/issues/11038

See https://github.com/astronomy-commons/lsdb/issues/270