### PR TITLE
Address smoke test failures from missing argument.

### DIFF
--- a/tests/data/generate_cloud_data.ipynb
+++ b/tests/data/generate_cloud_data.ipynb
@@ -61,7 +61,6 @@
     "    output_path=\"abfs://hipscat/pytests/data\",\n",
     "    output_artifact_name=\"small_sky\",\n",
     "    output_storage_options=storage_options,\n",
-    "    overwrite=True,\n",
     "    tmp_dir=tmp_dir,\n",
     "    dask_tmp=tmp_dir,\n",
     ")\n",
@@ -98,7 +97,6 @@
     "    output_artifact_name=\"small_sky_order1\",\n",
     "    tmp_dir=tmp_dir,\n",
     "    dask_tmp=tmp_dir,\n",
-    "    overwrite=True,\n",
     ")\n",
     "runner.pipeline(args)"
    ]
@@ -126,7 +124,6 @@
     "    output_storage_options=storage_options,\n",
     "    tmp_dir=tmp_dir,\n",
     "    dask_tmp=tmp_dir,\n",
-    "    overwrite=True,\n",
     ")\n",
     "runner.pipeline(args)"
    ]
@@ -145,7 +142,6 @@
     "    output_storage_options=storage_options,\n",
     "    tmp_dir=tmp_dir,\n",
     "    dask_tmp=tmp_dir,\n",
-    "    overwrite=True,\n",
     ")\n",
     "runner.pipeline(margin_args)"
    ]
@@ -173,7 +169,6 @@
     "    pixel_threshold=100,\n",
     "    tmp_dir=tmp_dir,\n",
     "    dask_tmp=tmp_dir,\n",
-    "    overwrite=True,\n",
     ")\n",
     "runner.pipeline(args)"
    ]

--- a/tests/data/generate_local_data.ipynb
+++ b/tests/data/generate_local_data.ipynb
@@ -50,7 +50,6 @@
     "    output_path=\".\",\n",
     "    file_reader=\"csv\",\n",
     "    output_artifact_name=\"small_sky\",\n",
-    "    overwrite=True,\n",
     "    tmp_dir=tmp_dir,\n",
     ")\n",
     "runner.pipeline(args)"
@@ -83,7 +82,6 @@
     "    file_reader=\"csv\",\n",
     "    output_artifact_name=\"small_sky_order1\",\n",
     "    constant_healpix_order=1,\n",
-    "    overwrite=True,\n",
     "    tmp_dir=tmp_dir,\n",
     ")\n",
     "runner.pipeline(args)"

--- a/tests/hipscat_import/test_run_catalog_import.py
+++ b/tests/hipscat_import/test_run_catalog_import.py
@@ -29,7 +29,6 @@ def test_catalog_import_write_to_cloud(
         dask_tmp=tmp_path,
         highest_healpix_order=1,
         progress_bar=False,
-        overwrite=True,
     )
 
     runner.run(args, dask_client)

--- a/tests/hipscat_import/test_run_index.py
+++ b/tests/hipscat_import/test_run_index.py
@@ -24,7 +24,6 @@ def test_run_index(
         output_storage_options=storage_options,
         tmp_dir=tmp_path,
         dask_tmp=tmp_path,
-        overwrite=True,
         progress_bar=False,
     )
     runner.run(args, dask_client)
@@ -75,7 +74,6 @@ def test_run_index_read_from_cloud(
         output_artifact_name="small_sky_object_index",
         tmp_dir=tmp_path,
         dask_tmp=tmp_path,
-        overwrite=True,
         progress_bar=False,
     )
     runner.run(args, dask_client)


### PR DESCRIPTION
The `overwrite` argument was removed in https://github.com/astronomy-commons/hipscat-import/pull/280