### PR TITLE
Address smoke test failures.

### DIFF
--- a/tests/hipscat/io/file_io/test_file_io_cloud.py
+++ b/tests/hipscat/io/file_io/test_file_io_cloud.py
@@ -6,8 +6,8 @@ from hipscat.io.file_io import (
     get_file_pointer_from_path,
     load_csv_to_pandas,
     load_json_file,
-    load_parquet_to_pandas,
     load_text_file,
+    read_parquet_file_to_pandas,
     write_dataframe_to_csv,
     write_string_to_file,
 )
@@ -37,14 +37,14 @@ def test_load_json(small_sky_dir_local, small_sky_dir_cloud, storage_options):
     assert json_dict_cloud == json_dict_local
 
 
-def test_load_parquet_to_pandas(
+def test_read_parquet_to_pandas(
     small_sky_catalog_cloud, small_sky_dir_local, small_sky_dir_cloud, storage_options
 ):
     pixel_data_path = pixel_catalog_file(small_sky_dir_local, 0, 11)
     pixel_data_path_cloud = pixel_catalog_file(small_sky_dir_cloud, 0, 11)
     parquet_df = pd.read_parquet(pixel_data_path)
     catalog_schema = small_sky_catalog_cloud.hc_structure.schema
-    loaded_df = load_parquet_to_pandas(
+    loaded_df = read_parquet_file_to_pandas(
         pixel_data_path_cloud, schema=catalog_schema, storage_options=storage_options
     )
     pd.testing.assert_frame_equal(parquet_df, loaded_df)

--- a/tests/hipscat_import/test_create_margin.py
+++ b/tests/hipscat_import/test_create_margin.py
@@ -1,5 +1,4 @@
 import hipscat_import.margin_cache.margin_cache as mc
-import pytest
 from hipscat.catalog.healpix_dataset.healpix_dataset import HealpixDataset
 from hipscat_import.margin_cache.margin_cache_arguments import MarginCacheArguments
 

--- a/tests/hipscat_import/test_create_margin.py
+++ b/tests/hipscat_import/test_create_margin.py
@@ -17,18 +17,17 @@ def test_margin_cache_gen(
     - local origin catalog.
     - writing to CLOUD.
     """
-    with pytest.warns(UserWarning, match="smaller resolution"):
-        args = MarginCacheArguments(
-            margin_threshold=7200.0,
-            input_catalog_path=small_sky_order1_dir_local,
-            output_path=tmp_cloud_path,
-            output_artifact_name="small_sky_order1_margin",
-            output_storage_options=storage_options,
-            dask_tmp=tmp_path,
-            tmp_dir=tmp_path,
-            margin_order=8,
-            progress_bar=False,
-        )
+    args = MarginCacheArguments(
+        input_catalog_path=small_sky_order1_dir_local,
+        output_path=tmp_cloud_path,
+        output_artifact_name="small_sky_order1_margin",
+        output_storage_options=storage_options,
+        dask_tmp=tmp_path,
+        tmp_dir=tmp_path,
+        margin_order=8,
+        fine_filtering=False,
+        progress_bar=False,
+    )
 
     assert args.catalog.catalog_info.ra_column == "ra"
 
@@ -51,18 +50,17 @@ def test_margin_cache_gen_read_from_cloud(
     - CLOUD origin catalog
     - writing to local tmp
     """
-    with pytest.warns(UserWarning, match="smaller resolution"):
-        args = MarginCacheArguments(
-            margin_threshold=7200.0,
-            input_catalog_path=small_sky_order1_dir_cloud,
-            input_storage_options=storage_options,
-            output_path=tmp_path,
-            output_artifact_name="small_sky_order1_margin",
-            dask_tmp=tmp_path,
-            tmp_dir=tmp_path,
-            margin_order=8,
-            progress_bar=False,
-        )
+    args = MarginCacheArguments(
+        input_catalog_path=small_sky_order1_dir_cloud,
+        input_storage_options=storage_options,
+        output_path=tmp_path,
+        output_artifact_name="small_sky_order1_margin",
+        dask_tmp=tmp_path,
+        tmp_dir=tmp_path,
+        margin_order=8,
+        fine_filtering=False,
+        progress_bar=False,
+    )
 
     assert args.catalog.catalog_info.ra_column == "ra"
 


### PR DESCRIPTION
- Remove call to removed method
- Remove expectation for removed warning (and drop fine filtering).